### PR TITLE
Remove inner Arc on memoised strategies

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -72,7 +72,7 @@ impl Default for ClientBuilder {
 }
 
 struct CachedFeature {
-    strategies: Arc<Vec<strategy::Evaluate>>,
+    strategies: Vec<strategy::Evaluate>,
     // unknown features are tracked for metrics (so the server can see that they
     // are being used). They require specific logic (see is_enabled).
     unknown: bool,
@@ -202,7 +202,7 @@ impl<C: http_client::HttpClient + std::default::Default> Client<C> {
                                 disabled: AtomicU64::new(if default { 0 } else { 1 }),
                                 enabled: AtomicU64::new(if default { 1 } else { 0 }),
                                 unknown: true,
-                                strategies: Arc::new(vec![]),
+                                strategies: vec![],
                             };
                             // Build up a new cached state
                             let mut new_state = CachedState {
@@ -253,7 +253,7 @@ impl<C: http_client::HttpClient + std::default::Default> Client<C> {
         for feature in features {
             if !feature.enabled {
                 // no strategies == return false per the unleash example code;
-                let strategies = Arc::new(vec![]);
+                let strategies = vec![];
                 let cached_feature = CachedFeature {
                     strategies,
                     disabled: AtomicU64::new(0),
@@ -273,7 +273,7 @@ impl<C: http_client::HttpClient + std::default::Default> Client<C> {
                 // TODO: add a logging layer and log it.
             }
             let cached_feature = CachedFeature {
-                strategies: Arc::new(strategies),
+                strategies: strategies,
                 disabled: AtomicU64::new(0),
                 enabled: AtomicU64::new(0),
                 unknown: false,


### PR DESCRIPTION
This was an attempt to fix the poor scaling of same-feature lookups but
has not worked. It is however a useful improvement to have.
```
single_call/single_call time:   [265.38 ns 266.55 ns 267.73 ns]
                        thrpt:  [3.7350 Melem/s 3.7516 Melem/s 3.7682 Melem/s]
50000 elements per thread below:
batch/single thread     time:   [13.502 ms 13.542 ms 13.583 ms]
                        thrpt:  [3.6812 Melem/s 3.6921 Melem/s 3.7030 Melem/s]
32 threads below:
batch/parallel same-feature
                        time:   [105.75 ms 107.96 ms 109.94 ms]
                        thrpt:  [14.554 Melem/s 14.821 Melem/s 15.129 Melem/s]
batch/parallel distinct-features
                        time:   [35.620 ms 36.025 ms 36.418 ms]
                        thrpt:  [43.934 Melem/s 44.414 Melem/s 44.919 Melem/s]
batch/parallel unknown-features
                        time:   [11.877 ms 12.104 ms 12.261 ms]
                        thrpt:  [130.50 Melem/s 132.19 Melem/s 134.71 Melem/s]
```
I may need to crack out CPU profiling tools next to determine what is
up. It isn't exactly slow : 500k lookups per thread per second still
allows lots of headroom for developers to use toggles with confidence,
but it would be nice to figure out the issue and fix it.

Close #2 