### PR TITLE
Use an enum for features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,20 @@ version = "0.2.0"
 [badges.maintenance]
 status = "experimental"
 
+[[bench]]
+harness = false
+name = "is_enabled"
+
+[[bin]]
+bench = false
+name = "dump-features"
+path = "src/bin/dump-features.rs"
+
 [dependencies]
 anyhow = "1.0.28"
 arc-swap = "0.4.6"
 async-std = "1.5.0"
+enum-map = "0.6.2"
 futures = "0.3.4"
 futures-timer = "3.0.2"
 hostname = "0.3.1"
@@ -30,6 +40,7 @@ maplit = "1.0.2"
 murmur3 = "0.5.1"
 rand = "0.7.3"
 serde_json = "1.0.52"
+serde_plain = "0.3"
 surf = "2.0.0-alpha.4"
 
 [dependencies.chrono]
@@ -49,17 +60,8 @@ simple_logger = "1.6.0"
 features = ["rt-threaded", "macros"]
 version = "0.2.20"
 
-[[bench]]
-name = "is_enabled"
-harness = false
-
 [features]
 functional = []
 
 [lib]
-bench=false
-
-[[bin]]
-name="dump-features"
-path="src/bin/dump-features.rs"
-bench=false
+bench = false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The crate documentation should be consulted for more detail.
 Core Unleash API features work, with Rust 1.42 or above.
 
 Missing Unleash specified features:
+
 - local serialised copy of toggles to survive restarts without network traffic.
 - variant support.
 
@@ -37,8 +38,10 @@ participating in this project you agree to abide by its terms.
 
 PR's on Github as normal please. Cargo test to run the test suite, rustfmt code
 before submitting. To run the functional test suite:
-```
+
+```shell
 docker-compose up -d
 UNLEASH_API_URL=http://127.0.0.1:4242/api UNLEASH_APP_NAME=fred UNLEASH_INSTANCE_ID=test cargo test --features functional  -- --nocapture
 ```
+
 or similar.

--- a/benches/is_enabled.rs
+++ b/benches/is_enabled.rs
@@ -12,20 +12,175 @@ use std::thread;
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use enum_map::Enum;
 use maplit::hashmap;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+use serde::{Deserialize, Serialize};
 
 use unleash_api_client::api::{Feature, Features, Strategy};
 use unleash_api_client::client;
 use unleash_api_client::context::Context;
 
-fn client(count: usize) -> client::Client<http_client::native::NativeClient> {
+// TODO: do a build.rs thing to determine available CPU count at build time for
+// optimal vec sizing.
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+enum UserFeatures {
+    Flexible0,
+    Flexible1,
+    Flexible2,
+    Flexible3,
+    Flexible4,
+    Flexible5,
+    Flexible6,
+    Flexible7,
+    Flexible8,
+    Flexible9,
+    Flexible10,
+    Flexible11,
+    Flexible12,
+    Flexible13,
+    Flexible14,
+    Flexible15,
+    Flexible16,
+    Flexible17,
+    Flexible18,
+    Flexible19,
+    Flexible20,
+    Flexible21,
+    Flexible22,
+    Flexible23,
+    Flexible24,
+    Flexible25,
+    Flexible26,
+    Flexible27,
+    Flexible28,
+    Flexible29,
+    Flexible30,
+    Flexible31,
+    Flexible32,
+    Flexible33,
+    Flexible34,
+    Flexible35,
+    Flexible36,
+    Flexible37,
+    Flexible38,
+    Flexible39,
+    Flexible40,
+    Flexible41,
+    Flexible42,
+    Flexible43,
+    Flexible44,
+    Flexible45,
+    Flexible46,
+    Flexible47,
+    Flexible48,
+    Flexible49,
+    Flexible50,
+    Flexible51,
+    Flexible52,
+    Flexible53,
+    Flexible54,
+    Flexible55,
+    Flexible56,
+    Flexible57,
+    Flexible58,
+    Flexible59,
+    Flexible60,
+    Flexible61,
+    Flexible62,
+    Flexible63,
+    Unknown0,
+    Unknown1,
+    Unknown2,
+    Unknown3,
+    Unknown4,
+    Unknown5,
+    Unknown6,
+    Unknown7,
+    Unknown8,
+    Unknown9,
+    Unknown10,
+    Unknown11,
+    Unknown12,
+    Unknown13,
+    Unknown14,
+    Unknown15,
+    Unknown16,
+    Unknown17,
+    Unknown18,
+    Unknown19,
+    Unknown20,
+    Unknown21,
+    Unknown22,
+    Unknown23,
+    Unknown24,
+    Unknown25,
+    Unknown26,
+    Unknown27,
+    Unknown28,
+    Unknown29,
+    Unknown30,
+    Unknown31,
+    Unknown32,
+    Unknown33,
+    Unknown34,
+    Unknown35,
+    Unknown36,
+    Unknown37,
+    Unknown38,
+    Unknown39,
+    Unknown40,
+    Unknown41,
+    Unknown42,
+    Unknown43,
+    Unknown44,
+    Unknown45,
+    Unknown46,
+    Unknown47,
+    Unknown48,
+    Unknown49,
+    Unknown50,
+    Unknown51,
+    Unknown52,
+    Unknown53,
+    Unknown54,
+    Unknown55,
+    Unknown56,
+    Unknown57,
+    Unknown58,
+    Unknown59,
+    Unknown60,
+    Unknown61,
+    Unknown62,
+    Unknown63,
+}
+
+fn client(count: usize) -> client::Client<http_client::native::NativeClient, UserFeatures> {
     let client = client::ClientBuilder::default()
-        .into_client::<http_client::native::NativeClient>("notused", "app", "test", None)
+        .enable_string_features()
+        .into_client::<http_client::native::NativeClient, UserFeatures>(
+            "notused", "app", "test", None,
+        )
         .unwrap();
     let mut features = vec![];
     for i in 0..count {
+        // once for enums, once for strings
+        let name = format!("Flexible{}", i);
+        features.push(Feature {
+            description: name.clone(),
+            enabled: true,
+            created_at: None,
+            variants: None,
+            name: name,
+            strategies: vec![Strategy {
+                name: "flexibleRollout".into(),
+                parameters: Some(hashmap!["stickiness".into()=>"DEFAULT".into(),
+                    "groupId".into()=>"flexible".into(), "rollout".into()=>"33".into()]),
+            }],
+        });
         let name = format!("flexible{}", i);
         features.push(Feature {
             description: name.clone(),
@@ -62,7 +217,7 @@ fn batch(c: &mut Criterion) {
         .throughput(Throughput::Elements(iterations as u64))
         .warm_up_time(Duration::from_secs(15))
         .measurement_time(Duration::from_secs(30));
-    group.bench_function("single thread", |b| {
+    group.bench_function("single thread(enum)", |b| {
         b.iter(|| {
             // Context creation is in here to make this comparable to parallel_same above.
             let context = Context {
@@ -70,14 +225,48 @@ fn batch(c: &mut Criterion) {
                 ..Default::default()
             };
             for _ in 0..iterations {
-                client.is_enabled("flexible0", Some(&context), false);
+                client.is_enabled(UserFeatures::Flexible0, Some(&context), false);
+            }
+        })
+    });
+    group.bench_function("single thread(str)", |b| {
+        b.iter(|| {
+            // Context creation is in here to make this comparable to parallel_same above.
+            let context = Context {
+                user_id: Some(thread_rng().sample_iter(&Alphanumeric).take(30).collect()),
+                ..Default::default()
+            };
+            for _ in 0..iterations {
+                client.is_enabled_str("flexible0", Some(&context), false);
             }
         })
     });
     group
         .throughput(Throughput::Elements(iterations * cpus as u64))
         .sample_size(10);
-    group.bench_function("parallel same-feature", |b| {
+    group.bench_function("parallel same-feature(enum)", |b| {
+        b.iter(|| {
+            let mut threads = vec![];
+            for _cpu in 0..cpus {
+                let thread_client = client.clone();
+                let feature = UserFeatures::Flexible0;
+                let handle = thread::spawn(move || {
+                    let context = Context {
+                        user_id: Some(thread_rng().sample_iter(&Alphanumeric).take(30).collect()),
+                        ..Default::default()
+                    };
+                    for _ in 0..iterations {
+                        thread_client.is_enabled(feature.clone(), Some(&context), false);
+                    }
+                });
+                threads.push(handle);
+            }
+            for thread in threads {
+                thread.join().unwrap();
+            }
+        })
+    });
+    group.bench_function("parallel same-feature(str)", |b| {
         b.iter(|| {
             let mut threads = vec![];
             for _cpu in 0..cpus {
@@ -89,7 +278,7 @@ fn batch(c: &mut Criterion) {
                         ..Default::default()
                     };
                     for _ in 0..iterations {
-                        thread_client.is_enabled(&feature, Some(&context), false);
+                        thread_client.is_enabled_str(&feature, Some(&context), false);
                     }
                 });
                 threads.push(handle);
@@ -99,19 +288,21 @@ fn batch(c: &mut Criterion) {
             }
         })
     });
-    group.bench_function("parallel distinct-features", |b| {
+
+    group.bench_function("parallel distinct-features(enum)", |b| {
         b.iter(|| {
             let mut threads = vec![];
             for cpu in 0..cpus {
                 let thread_client = client.clone();
-                let feature = format!("flexible{}", cpu);
+                let feature_str = format!("Flexible{}", cpu);
+                let feature = serde_plain::from_str::<UserFeatures>(&feature_str).unwrap();
                 let handle = thread::spawn(move || {
                     let context = Context {
                         user_id: Some(thread_rng().sample_iter(&Alphanumeric).take(30).collect()),
                         ..Default::default()
                     };
                     for _ in 0..iterations {
-                        thread_client.is_enabled(&feature, Some(&context), false);
+                        thread_client.is_enabled(feature.clone(), Some(&context), false);
                     }
                 });
                 threads.push(handle);
@@ -121,19 +312,64 @@ fn batch(c: &mut Criterion) {
             }
         })
     });
-    group.bench_function("parallel unknown-features", |b| {
+    group.bench_function("parallel distinct-features(str)", |b| {
         b.iter(|| {
             let mut threads = vec![];
             for cpu in 0..cpus {
                 let thread_client = client.clone();
-                let feature = format!("unknown{}", cpu);
+                let feature_str = format!("flexible{}", cpu);
                 let handle = thread::spawn(move || {
                     let context = Context {
                         user_id: Some(thread_rng().sample_iter(&Alphanumeric).take(30).collect()),
                         ..Default::default()
                     };
                     for _ in 0..iterations {
-                        thread_client.is_enabled(&feature, Some(&context), false);
+                        thread_client.is_enabled_str(&feature_str, Some(&context), false);
+                    }
+                });
+                threads.push(handle);
+            }
+            for thread in threads {
+                thread.join().unwrap();
+            }
+        })
+    });
+    group.bench_function("parallel unknown-features(enum)", |b| {
+        b.iter(|| {
+            let mut threads = vec![];
+            for cpu in 0..cpus {
+                let thread_client = client.clone();
+                let feature_str = format!("Unknown{}", cpu);
+                let feature = serde_plain::from_str::<UserFeatures>(&feature_str).unwrap();
+                let handle = thread::spawn(move || {
+                    let context = Context {
+                        user_id: Some(thread_rng().sample_iter(&Alphanumeric).take(30).collect()),
+                        ..Default::default()
+                    };
+                    for _ in 0..iterations {
+                        thread_client.is_enabled(feature.clone(), Some(&context), false);
+                    }
+                });
+                threads.push(handle);
+            }
+            for thread in threads {
+                thread.join().unwrap();
+            }
+        })
+    });
+    group.bench_function("parallel unknown-features(str)", |b| {
+        b.iter(|| {
+            let mut threads = vec![];
+            for cpu in 0..cpus {
+                let thread_client = client.clone();
+                let feature_str = format!("unknown{}", cpu);
+                let handle = thread::spawn(move || {
+                    let context = Context {
+                        user_id: Some(thread_rng().sample_iter(&Alphanumeric).take(30).collect()),
+                        ..Default::default()
+                    };
+                    for _ in 0..iterations {
+                        thread_client.is_enabled_str(&feature_str, Some(&context), false);
                     }
                 });
                 threads.push(handle);
@@ -155,11 +391,17 @@ fn single_call(c: &mut Criterion) {
     };
     let mut group = c.benchmark_group("single_call");
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single_call", |b| {
+    group.bench_function("single_call(enum)", |b| {
         b.iter(|| {
-            client.is_enabled("flexible0", Some(&context), false);
+            client.is_enabled(UserFeatures::Flexible0, Some(&context), false);
         })
     });
+    group.bench_function("single_call(str)", |b| {
+        b.iter(|| {
+            client.is_enabled_str("flexible0", Some(&context), false);
+        })
+    });
+
     group.finish();
 }
 

--- a/examples/async-std.rs
+++ b/examples/async-std.rs
@@ -8,10 +8,18 @@
 use std::time::Duration;
 
 use async_std::task;
+use enum_map::Enum;
 use futures_timer::Delay;
+use serde::{Deserialize, Serialize};
 
 use unleash_api_client::client;
 use unleash_api_client::config::EnvironmentConfig;
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+enum UserFeatures {
+    default,
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let _ = simple_logger::init();
@@ -19,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let config = EnvironmentConfig::from_env()?;
         let client = client::ClientBuilder::default()
             .interval(500)
-            .into_client::<http_client::native::NativeClient>(
+            .into_client::<http_client::native::NativeClient, UserFeatures>(
             &config.api_url,
             &config.app_name,
             &config.instance_id,
@@ -31,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             Delay::new(Duration::from_millis(500)).await;
             println!(
                 "feature 'default' is {}",
-                client.is_enabled("default", None, false)
+                client.is_enabled(UserFeatures::default, None, false)
             );
             // Wait to allow metrics upload
             Delay::new(Duration::from_millis(500)).await;

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -10,9 +10,17 @@ use std::thread;
 use std::time::Duration;
 
 use async_std::task;
+use enum_map::Enum;
+use serde::{Deserialize, Serialize};
 
 use unleash_api_client::client;
 use unleash_api_client::config::EnvironmentConfig;
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+enum UserFeatures {
+    default,
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let _ = simple_logger::init();
@@ -20,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let client = Arc::new(
         client::ClientBuilder::default()
             .interval(500)
-            .into_client::<http_client::native::NativeClient>(
+            .into_client::<http_client::native::NativeClient, UserFeatures>(
                 &config.api_url,
                 &config.app_name,
                 &config.instance_id,
@@ -48,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     thread::sleep(Duration::from_millis(500));
     println!(
         "feature 'default' is {}",
-        client.is_enabled("default", None, false)
+        client.is_enabled(UserFeatures::default, None, false)
     );
     // Wait to allow metrics upload
     thread::sleep(Duration::from_millis(500));

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -7,10 +7,18 @@
 
 use std::time::Duration;
 
+use enum_map::Enum;
 use futures_timer::Delay;
+use serde::{Deserialize, Serialize};
 
 use unleash_api_client::client;
 use unleash_api_client::config::EnvironmentConfig;
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+enum UserFeatures {
+    default,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -18,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     let config = EnvironmentConfig::from_env()?;
     let client = client::ClientBuilder::default()
         .interval(500)
-        .into_client::<http_client::native::NativeClient>(
+        .into_client::<http_client::native::NativeClient, UserFeatures>(
             &config.api_url,
             &config.app_name,
             &config.instance_id,
@@ -30,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         Delay::new(Duration::from_millis(500)).await;
         println!(
             "feature 'default' is {}",
-            client.is_enabled("default", None, false)
+            client.is_enabled(UserFeatures::default, None, false)
         );
         // Wait to allow metrics upload
         Delay::new(Duration::from_millis(500)).await;

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,7 @@ impl Features {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Feature {
     pub name: String,
@@ -31,14 +31,14 @@ pub struct Feature {
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Strategy {
     pub name: String,
     pub parameters: Option<HashMap<String, String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Variant {
     pub name: String,
@@ -47,7 +47,7 @@ pub struct Variant {
     pub overrides: Option<Vec<VariantOverride>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct VariantOverride {
     #[serde(rename = "contextName")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@
 //! use std::time::Duration;
 //!
 //! use async_std::task;
+//! use enum_map::Enum;
 //! use futures_timer::Delay;
+//! use serde::{Deserialize, Serialize};
 //!
 //! use unleash_api_client::client;
 //! use unleash_api_client::config::EnvironmentConfig;
@@ -51,13 +53,19 @@
 //!     })
 //! }
 //!
+//! #[allow(non_camel_case_types)]
+//! #[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+//! enum UserFeatures {
+//!     default
+//! }
+//!
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     let _ = simple_logger::init();
 //!     task::block_on(async {
 //!         let config = EnvironmentConfig::from_env()?;
 //!         let client = client::ClientBuilder::default()
 //!             .strategy("reversed", Box::new(&_reversed_uids))
-//!             .into_client::<http_client::native::NativeClient>(
+//!             .into_client::<http_client::native::NativeClient, UserFeatures>(
 //!                 &config.api_url,
 //!                 &config.app_name,
 //!                 &config.instance_id,
@@ -67,7 +75,7 @@
 //!         futures::future::join(client.poll_for_updates(), async {
 //!             // Ensure we have initial load of features completed
 //!             Delay::new(Duration::from_millis(500)).await;
-//!             assert_eq!(true, client.is_enabled("default", None, false));
+//!             assert_eq!(true, client.is_enabled(UserFeatures::default, None, false));
 //!             // ... serve more requests
 //!             client.stop_poll().await;
 //!         }).await;
@@ -93,10 +101,19 @@ pub use crate::strategy::Evaluate;
 /// For the complete minimalist
 ///
 /// ```no_run
+/// use enum_map::Enum;
+/// use serde::{Deserialize, Serialize};
 /// use unleash_api_client::prelude::*;
 /// let config = EnvironmentConfig::from_env()?;
+///
+/// #[allow(non_camel_case_types)]
+/// #[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+/// enum UserFeatures {
+///     feature
+/// }
+///
 /// let client = ClientBuilder::default()
-///     .into_client::<http_client::native::NativeClient>(
+///     .into_client::<http_client::native::NativeClient, UserFeatures>(
 ///         &config.api_url,
 ///         &config.app_name,
 ///         &config.instance_id,


### PR DESCRIPTION
There are two benefits: type safety: no features that fire in one code
path and not another because it was mis-typed in the second path; and
performance.

Implemenation wise this involves parameterising the client with an enum
containing the features, rather than having typeless string lookups
everywhere. I've kept the string hash-based capability as an optional
facility - it may be useful for situations where the full set of
features cannot be known at compile time for some reason reason - e.g.
if some form of runtime code interpretation is in effect, or if this
code is being used to deliver a toggles-as-a-service facility of some
sort, where the known set of toggles in the clients could be out of sync
and thus a potential super-set of the enumerable toggles.

The performance benefit is small but pleasant:
```
single_call/single_call(enum)
            time:   [139.97 ns 141.33 ns 142.59 ns]
            thrpt:  [7.0130 Melem/s 7.0756 Melem/s 7.1443 Melem/s]
single_call/single_call(str)
            time:   [171.59 ns 173.40 ns 175.06 ns]
            thrpt:  [5.7125 Melem/s 5.7670 Melem/s 5.8279 Melem/s]
```
There's still the contention at the higher cpu tests that prevents this
translating to a real world result, but I'm pretty sure it is a useful
improvement to make simply because of the type safety benefits.