### PR TITLE
More use cases

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -10,7 +10,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.42.0  # MSRV
+          - 1.43.0  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The crate documentation should be consulted for more detail.
 
 ## status
 
-Core Unleash API features work, with Rust 1.42 or above.
+Core Unleash API features work, with Rust 1.43 or above.
 
 Missing Unleash specified features:
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -141,7 +141,8 @@ where
     instance_id: String,
     interval: u64,
     polling: AtomicBool,
-    http: HTTP<C>,
+    // Permits making extension calls to the Unleash API not yet modelled in the Rust SDK.
+    pub http: HTTP<C>,
     // known strategies: strategy_name : memoiser
     strategies: Mutex<HashMap<String, strategy::Strategy>>,
     // memoised state: feature_name: [callback, callback, ...]


### PR DESCRIPTION
The state exposure patch permits more sophisticated use by clients while still keeping the
safe properties the design has had from the start.

Disabling metrics is useful for some specialised clients, as is being able to do custom HTTP requests.